### PR TITLE
Typo in configuration reference

### DIFF
--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -28,6 +28,6 @@ sp_bower:
         DemoBundle:
             config_dir: Resources/config/bower # Can be relative to the bundles root directory, absolute or a bundle notation
             asset_dir: ../../public/components # Can be relative to the config_dir directory, absolute or a bundle notation
-            json: components.json
+            json_file: component.json
             endpoint: https://bower.herokuapp.com
 ```


### PR DESCRIPTION
It seems like the json_file parameter and its default value have not been updated at some point in the reference documentation
