### PR TITLE
Added support for the scripts property

### DIFF
--- a/Assetic/BowerResource.php
+++ b/Assetic/BowerResource.php
@@ -221,6 +221,15 @@ class BowerResource extends ConfigurationResource implements \Serializable
             }
         }
 
+        if (isset($package['source']['scripts'])) {
+            if (is_string($package['source']['scripts'])) {
+                array_push($files, $package['source']['scripts']);
+            } else if (is_array($package['source']['scripts'])) {
+                $files = array_merge($files, $package['source']['scripts']);
+            }
+        }
+
+
         $cssFiles = array();
         $jsFiles = array();
         if (isset($package['dependencies'])) {

--- a/Bower/Bower.php
+++ b/Bower/Bower.php
@@ -135,6 +135,16 @@ class Bower
                     }
                 }
             }
+            if (isset($package['source']['scripts'])) {
+                $files = $package['source']['scripts'];
+                if (is_string($files)) {
+                    $mapping[$packageName]['source']['scripts'] = $this->resolvePath($config->getDirectory(), $files);
+                } else {
+                    foreach ($files as $key => $source) {
+                        $mapping[$packageName]['source']['scripts'][$key] = $this->resolvePath($config->getDirectory(), $source);
+                    }
+                }
+            }
         }
 
         return $mapping;

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@ Changelog
 
 ### 0.7-dev
 
+* Added support for scripts property in the component.json file. As used in node and implemented in the jquery component.
 ...
 
 ### 0.6 (2013-04-06)


### PR DESCRIPTION
Hi,

I made a quick fix for the scripts property in the component.json-file for direct usage in assetic.
jQuery works now as it should again.
Maybe it would be better to add a config param, which properties should be available in assetic.

Best
Johannes
