### PR TITLE
Documentation broken link fix

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -10,7 +10,7 @@ This bundle requires Symfony 2.1+
 
 In order to use this bundle you have to install bower
 
-[Bower Documentation](http://twitter.github.com/bower/)
+[Bower Documentation](http://bower.io/)
 
 Installation
 ------------


### PR DESCRIPTION
Fixed bower's homepage link from http://twitter.github.io/bower/ to http://bower.io/
