### PR TITLE
Symfony 2.3 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": ">=2.1,<2.3-dev",
-        "symfony/process": ">=2.1,<2.3-dev",
-        "symfony/assetic-bundle": ">=2.1,<2.3-dev"
+        "symfony/framework-bundle": "~2.1",
+        "symfony/process": "~2.1",
+        "symfony/assetic-bundle": "~2.1"
     },
     "require-dev":{
-        "symfony/console": ">=2.1,<2.3-dev",
+        "symfony/console": "~2.1",
         "phpunit/phpunit": "3.7.*"
     },
     "config": {


### PR DESCRIPTION
Currently SpBowerBundle won't install in SF-2.3 projects, so I updated the version constraints in the composer.json file.
