### PR TITLE
Fixes serializing BowerResource instances

### DIFF
--- a/Assetic/BowerResource.php
+++ b/Assetic/BowerResource.php
@@ -174,7 +174,7 @@ class BowerResource extends ConfigurationResource implements \Serializable
      */
     public function unserialize($serialized)
     {
-        list($this->cssFilters, $this->jsFilter, $this->packageResources, $this->packageCssFilters) = unserialize($serialized);
+        list($this->cssFilters, $this->jsFilter, $this->packageResources) = unserialize($serialized);
     }
 
     /**
@@ -182,7 +182,7 @@ class BowerResource extends ConfigurationResource implements \Serializable
      */
     public function serialize()
     {
-        return serialize(array($this->cssFilters, $this->jsFilters, $this->packageResources, $this->packageCssFilters));
+        return serialize(array($this->cssFilters, $this->jsFilters, $this->packageResources));
     }
 
     /**


### PR DESCRIPTION
This fixes a bug which appears when serializing instances of BowerResource. Because packageCssFilters is not defined, a PHP notice will arise.
