### PR TITLE
Fix createDependencyMappingCache for bower 1.0+

### DIFF
--- a/Bower/Bower.php
+++ b/Bower/Bower.php
@@ -92,7 +92,7 @@ class Bower
      */
     public function createDependencyMappingCache(ConfigurationInterface $config)
     {
-        $result = $this->execCommand($config, array('list', '--map'));
+        $result = $this->execCommand($config, array('list', '--map', '--json'));
         $output = $result->getProcess()->getOutput();
         if (strpos($output, 'error')) {
             throw new MappingException(sprintf('An error occurred while creating dependency mapping. The error was %s.', $output));


### PR DESCRIPTION
The method createDependencyMappingCache throws a MappingException when using bower 1.0+ because since this version `bower list --map` returns a formatted string instead of JSON by default. By using the --json option, bower is forced to return a JSON-string.
