### PR TITLE
Adding ListCommand closes #41

### DIFF
--- a/Command/ListCommand.php
+++ b/Command/ListCommand.php
@@ -3,7 +3,7 @@
 /*
  * This file is part of the SpBowerBundle package.
  *
- * (c) Luis Hdez <luis.munoz.hdez@gmail.com>
+ * (c) Martin Parsiegla <martin.parsiegla@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -15,6 +15,9 @@ use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputInterface;
 
+/**
+ * @author Luis Hdez <luis.munoz.hdez@gmail.com>
+ */
 class ListCommand extends ContainerAwareCommand
 {
     protected function configure()


### PR DESCRIPTION
I had to write the command for debugging, you may pull it if you want to. Can't guarantee that this is the most elegant way to do it.

![list-command](https://f.cloud.github.com/assets/319268/1441223/6a005738-41a8-11e3-8a94-2af17689f3ea.png)
