### PR TITLE
Reset working directory on DependencyMapper

### DIFF
--- a/Bower/Package/DependencyMapper.php
+++ b/Bower/Package/DependencyMapper.php
@@ -157,6 +157,7 @@ class DependencyMapper implements DependencyMapperInterface
      */
     private function resolvePath($file)
     {
+        $resetDir = getcwd();
         chdir($this->config->getDirectory());
         if (strpos($file, '@') === 0) {
             return $file;
@@ -169,7 +170,11 @@ class DependencyMapper implements DependencyMapperInterface
             );
         }
 
-        return realpath($file) ? : "";
+        $path = realpath($file) ? : "";
+
+        chdir($resetDir);
+
+        return $path;
     }
 
     /**


### PR DESCRIPTION
I noticed the chdir() was causing trouble in other bundles that used the current working directory, cause it was never reset.
