### PR TITLE
Added support for HHVM in ScriptHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3.3",
         "symfony/framework-bundle": "~2.1",
-        "symfony/process": "~2.1",
+        "symfony/process": "~2.3,>=2.3.20 | ~2.4,>=2.4.10 | ~2.5,>=2.5.5",
         "doctrine/collections": "1.*",
         "symfony/assetic-bundle": "~2.1",
         "doctrine/cache": "~1.0"


### PR DESCRIPTION
See https://github.com/sensiolabs/SensioDistributionBundle/pull/150

symfony/process version requirements bumped.

Otherwise:
```
sh: 1: /usr/bin/hhvm --php: not found
Script Sp\BowerBundle\Composer\ScriptHandler::bowerInstall handling the post-install-cmd event terminated with an exception

  [RuntimeException]
  An error occurred when executing the "'sp:bower:install'" command.

Exception trace:
 () at /project/vendor/sp/bower-bundle/Composer/ScriptHandler.php:94
 Sp\BowerBundle\Composer\ScriptHandler::executeCommand() at /project/vendor/sp/bower-bundle/Composer/ScriptHandler.php:46
 Sp\BowerBundle\Composer\ScriptHandler::bowerInstall() at phar://composer.phar/bin/../src/../src/Composer/EventDispatcher/EventDispatcher.php:207
 Composer\EventDispatcher\EventDispatcher->executeEventPhpScript() at phar://composer.phar/bin/../src/../src/Composer/EventDispatcher/EventDispatcher.php:175
 Composer\EventDispatcher\EventDispatcher->doDispatch() at phar://composer.phar/bin/../src/../src/Composer/EventDispatcher/EventDispatcher.php:121
 Composer\EventDispatcher\EventDispatcher->dispatchCommandEvent() at phar://composer.phar/bin/../src/../src/Composer/Installer.php:337
 Composer\Installer->run() at phar://composer.phar/bin/../src/../src/Composer/Command/InstallCommand.php:131
 Composer\Command\InstallCommand->execute() at phar://composer.phar/bin/../src/../vendor/symfony/console/Symfony/Component/Console/Command/Command.php:252
 Symfony\Component\Console\Command\Command->run() at phar://composer.phar/bin/../src/../vendor/symfony/console/Symfony/Component/Console/Application.php:874
 Symfony\Component\Console\Application->doRunCommand() at phar://composer.phar/bin/../src/../vendor/symfony/console/Symfony/Component/Console/Application.php:195
 Symfony\Component\Console\Application->doRun() at phar://composer.phar/bin/../src/../src/Composer/Console/Application.php:146
 Composer\Console\Application->doRun() at phar://composer.phar/bin/../src/../vendor/symfony/console/Symfony/Component/Console/Application.php:126
 Symfony\Component\Console\Application->run() at phar://composer.phar/bin/../src/../src/Composer/Console/Application.php:83
 Composer\Console\Application->run() at phar://composer.phar/bin/composer:43
 include() at /usr/lib/composer/composer.phar:25
```