### PR TITLE
Avoid TTY error on Windows

### DIFF
--- a/Bower/Bower.php
+++ b/Bower/Bower.php
@@ -240,7 +240,10 @@ class Bower
         }
 
         $proc = $pb->getProcess();
-        $proc->setTty($tty);
+        // TTY is not available on Windows.
+        if(DIRECTORY_SEPARATOR == '/'){
+            $proc->setTty($tty);
+        }
         $proc->run($callback);
 
         if (!$proc->isSuccessful()) {


### PR DESCRIPTION
This fixes an error when running sp:bower:install on Windows, which throws this exception:

[Symfony\Component\Process\Exception\RuntimeException]
  TTY mode is not supported on Windows platform.