### PR TITLE
Passing `false` as `--interactive` option value doesn't disable TTY mode

### DIFF
--- a/Bower/Bower.php
+++ b/Bower/Bower.php
@@ -242,6 +242,7 @@ class Bower
         $proc = $pb->getProcess();
         // TTY is not available on Windows.
         if(DIRECTORY_SEPARATOR == '/'){
+            $tty = filter_var($tty, FILTER_VALIDATE_BOOLEAN);
             $proc->setTty($tty);
         }
         $proc->run($callback);


### PR DESCRIPTION
I've encountered the following error when running `sp:bower:install` command with `jenkins` for continuous integration:

`PHP Warning:  proc_open(/dev/tty): failed to open stream: No such device or address in vendor/symfony/symfony/src/Symfony/Component/Process/Process.php on line 289`

`[Symfony\Component\Process\Exception\RuntimeException]`
`Unable to launch a new process.`

Passing `false` (instead of `0`) to the command line results in running the command in interactive mode as the `setTty` method of the `Process` class casts the `$tty` variable containing the `"false"` string to a boolean (See also https://github.com/symfony/process/blob/master/Process.php#L932)

I've filtered the option as a boolean to have the commands behave as expected:

